### PR TITLE
check if a spider exists before schedule it

### DIFF
--- a/scrapyd/webservice.py
+++ b/scrapyd/webservice.py
@@ -31,6 +31,9 @@ class Schedule(WsResource):
         args = dict((k, v[0]) for k, v in txrequest.args.items())
         project = args.pop('project')
         spider = args.pop('spider')
+        spiders = get_spider_list(project)
+        if not spider in spiders:
+            return {"status": "error", "message": "spider '%s' not found" % spider}
         args['settings'] = settings
         jobid = uuid.uuid1().hex
         args['_job'] = jobid


### PR DESCRIPTION
A simple check before schedule a spider. 

By default it is possible to schedule anything using Scrapyd API:
curl http://localhost:6800/schedule.json -d project=default -d spider=nospider

this command returns {"status": "ok", "jobid": "455c1444a6c611e29f650800272a6d06"}
and also a misleading log like this https://gist.github.com/artem-dev/8a567c1775ab9bb8d122 will be created (this gist contains the complete log)

With this check nothing will be scheduled and the response will be like this:
{"status": "error", "message": "spider 'nospider' not found"}
