### PR TITLE
Removed python 2.6/lucid env from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
     exclude:
         - env: TRAVISBUG="#1027"
     include:
-        - python: "2.6"
-          env: BUILDENV=lucid
         - python: "2.7"
           env: BUILDENV=precise
         - python: "2.7"


### PR DESCRIPTION
Scrapy no longer supports python 2.6.

Currently travis reports build failures: https://travis-ci.org/scrapy/scrapyd/jobs/14868466
