### PR TITLE
debian sysvinit script

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,12 +9,18 @@ Homepage: http://scrapy.org/
 Package: scrapyd
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, scrapy
-Description: Scrapyd server
- This package deploys and configures Scrapyd to run as a system service.
+Description: Service to host scrapy crawlers
+ This package installs and configures Scrapyd to run as a system service.
+ .
+ Scrapyd is an application for deploying and running Scrapy spiders.
+ It enables you to deploy (upload) your projects and control their spiders
+ using an API.
 
 Package: scrapyd-deploy
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, scrapy, python-w3lib, python-setuptools
 Description: Scrapyd deployment tool
- The package contains the Scrapyd deployment tool which is used to deploy
- Scrapy projects to Scrapyd servers.
+ The package contains the Scrapyd deployment tool.
+ .
+ scrapyd-deploy is used to deploy Scrapy projects to Scrapyd servers.
+ It contains the same functionality as provided by the `scrapy deploy` command.

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,9 +4,9 @@ It was downloaded from http://scrapy.org
 
 Upstream Author: Scrapy Developers
 
-Copyright: 2007-2012 Scrapy Developers
+Copyright: 2007-2014 Scrapy Developers
 
-License: bsd
+License: BSD
 
 Copyright (c) Scrapy developers.
 All rights reserved.
@@ -14,10 +14,10 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, 
+    1. Redistributions of source code must retain the above copyright notice,
        this list of conditions and the following disclaimer.
-    
-    2. Redistributions in binary form must reproduce the above copyright 
+
+    2. Redistributions in binary form must reproduce the above copyright
        notice, this list of conditions and the following disclaimer in the
        documentation and/or other materials provided with the distribution.
 
@@ -35,6 +35,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The Debian packaging is (C) 2010-2012, Scrapinghub <info@scrapinghub.com> and
-is licensed under the BSD, see `/usr/share/common-licenses/BSD'.

--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -1,3 +1,1 @@
-new-package-should-close-itp-bug
 package-installs-python-egg
-binary-without-manpage usr/bin/scrapyd

--- a/debian/scrapyd.init
+++ b/debian/scrapyd.init
@@ -1,11 +1,12 @@
 #!/bin/bash
 ### BEGIN INIT INFO
 # Provides:          scrapyd
-# Required-Start:    $local_fs $network
-# Required-Stop:     $local_fs
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Scrapyd
+# Description:       Run the scrapyd service as a system service.
 ### END INIT INFO
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script


### PR DESCRIPTION
This is the custom initscript I use on my box,
this shouldn't affect ubuntu using the upstart script I think, but please build-test before merge as I have no Ubuntu to test on right now.

Then I saw these lintian warnings and tried fixing them:

``` sh
W: scrapyd: copyright-refers-to-deprecated-bsd-license-file
P: scrapyd: copyright-with-old-dh-make-debian-copyright
E: scrapyd: description-starts-with-package-name
I: scrapyd: extended-description-is-probably-too-short
I: scrapyd: init.d-script-missing-lsb-description etc/init.d/scrapyd
E: scrapyd: init.d-script-missing-dependency-on-remote_fs etc/init.d/scrapyd: required-start
E: scrapyd: init.d-script-missing-dependency-on-remote_fs etc/init.d/scrapyd: required-stop
I: scrapyd: unused-override new-package-should-close-itp-bug
W: scrapyd-deploy: copyright-refers-to-deprecated-bsd-license-file
P: scrapyd-deploy: copyright-with-old-dh-make-debian-copyright
I: scrapyd-deploy: extended-description-is-probably-too-short
```

Not fixed are:

``` sh
W: scrapyd-deploy: binary-without-manpage usr/bin/scrapyd-deploy
W: scrapyd: binary-without-manpage usr/bin/scrapyd
```
