### PR TITLE
Use most recently uploaded egg by default ignoring versioning

### DIFF
--- a/scrapyd/tests/test_eggstorage.py
+++ b/scrapyd/tests/test_eggstorage.py
@@ -27,8 +27,8 @@ class EggStorageTest(unittest.TestCase):
         self.assertEqual(self.eggst.list('mybot2'), [])
 
         v, f = self.eggst.get('mybot')
-        self.assertEqual(v, "03")
-        self.assertEqual(f.read(), "egg03")
+        self.assertEqual(v, "latest")
+        self.assertEqual(f.read(), "egg02")
         f.close()
 
         v, f = self.eggst.get('mybot', '02')


### PR DESCRIPTION
This PR intends to fix #34 

There are some loose ends:
1. It doesn't consider the egg version when choosing the default eggfile to run, it required changes to test cases. To be honest I'm not sure this can be considered a bugfix.
2. It doesn't handle the case when the version pointed by "latest" is removed by `deleteversion.json` api call. Suggestions on how to handle this case are welcome.
3. `listversions.json` shows available versions sorted using `LooseVersion`  but it doesn't show which is the "latest" version.

so.. why am I submitting thi PR anyway, because it was my idea but I am not happy with the results. And I hope you can help me convince @pablohoffman it is not worth merging it. :)
