### PR TITLE
Renovate scrapy upstart job a bit

### DIFF
--- a/debian/scrapyd.upstart
+++ b/debian/scrapyd.upstart
@@ -5,4 +5,7 @@ stop on runlevel [016] or unmounting-filesystem
 
 chdir /var/lib/scrapyd
 
-exec /usr/bin/scrapyd -u scrapy -g nogroup -l /var/log/scrapyd/scrapyd.log
+script
+  [ -r /etc/default/scrapyd ] && . /etc/default/scrapyd
+  exec /usr/bin/scrapyd -u scrapy -g nogroup -l /var/log/scrapyd/scrapyd.log
+end script

--- a/debian/scrapyd.upstart
+++ b/debian/scrapyd.upstart
@@ -1,12 +1,8 @@
-# Scrapy service
+description "scrapyd - run Scrapy spiders"
 
 start on runlevel [2345]
-stop on runlevel [06]
+stop on runlevel [016] or unmounting-filesystem
 
-script
-    [ -r /etc/default/scrapyd ] && . /etc/default/scrapyd
-    logdir=/var/log/scrapyd
-    exec scrapyd -u scrapy -g nogroup \
-                --pidfile /var/run/scrapyd.pid \
-                -l $logdir/scrapyd.log >$logdir/scrapyd.out 2>$logdir/scrapyd.err
-end script
+chdir /var/lib/scrapyd
+
+exec /usr/bin/scrapyd -u scrapy -g nogroup -l /var/log/scrapyd/scrapyd.log


### PR DESCRIPTION
No need to redirect stdout/err, upstart will catch that. Use chdir stanza to keep up to date with init script, do not source empty/useless defaults file.