### PR TITLE
If the items_dir option doesn't have a file scheme, a file URI won't be used

### DIFF
--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -38,8 +38,8 @@ class Environment(object):
 
     def _get_feed_uri(self, message, ext):
         url = urlparse(self.items_dir)
-        if url.scheme.lower() in ['', 'file']:
-            return path_to_file_uri(self._get_file(message, url.path, ext))
+        if url.scheme.lower() is 'file':
+            return 'file://' + self._get_file(message, url.path, ext)
         return urlunparse((url.scheme,
                            url.netloc,
                            '/'.join([url.path,


### PR DESCRIPTION
This fix the issue 56. Relative path wasn't working for the `items_dir`.