### PR TITLE
Fix: FEED_URI was always overriden by scrapyd

### DIFF
--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -12,7 +12,7 @@ class Environment(object):
     def __init__(self, config, initenv=os.environ):
         self.dbs_dir = config.get('dbs_dir', 'dbs')
         self.logs_dir = config.get('logs_dir', 'logs')
-        self.items_dir = config.get('items_dir', 'items')
+        self.items_dir = config.get('items_dir','')
         self.jobs_to_keep = config.getint('jobs_to_keep', 5)
         if config.cp.has_section('settings'):
             self.settings = dict(config.cp.items('settings'))

--- a/scrapyd/tests/test_environ.py
+++ b/scrapyd/tests/test_environ.py
@@ -30,7 +30,8 @@ class EnvironmentTest(unittest.TestCase):
         self.assertEqual(env['SCRAPY_SPIDER'], 'myspider')
         self.assertEqual(env['SCRAPY_JOB'], 'ID')
         self.assert_(env['SCRAPY_LOG_FILE'].endswith(os.path.join('mybot', 'myspider', 'ID.log')))
-        self.assert_(env['SCRAPY_FEED_URI'].endswith(os.path.join('mybot', 'myspider', 'ID.jl')))
+        if env.get('SCRAPY_FEED_URI'): #not compulsory
+            self.assert_(env['SCRAPY_FEED_URI'].endswith(os.path.join('mybot', 'myspider', 'ID.jl')))
         self.failIf('SCRAPY_SETTINGS_MODULE' in env)
 
     def test_get_environment_with_no_items_dir(self):


### PR DESCRIPTION
FEED_URI setting under scrapyd had no effect, it always saved feeds into file - see reports such as:
http://stackoverflow.com/questions/15955723/saving-items-from-scrapyd-to-amazon-s3-using-feed-exporter and https://groups.google.com/forum/#!topic/scrapy-users/pl4_TpkLlFY  