### PR TITLE
[#28] Control log filename with logs_filename cfg

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -68,6 +68,23 @@ storing logs set this option empty, like this::
 
     logs_dir =
 
+logs_filename
+-------------
+
+The filename (appended to ``logs_dir``) to use for the crawl. ``{project}``
+and ``{spider}`` placeholders will be substituted, as will certain datetime
+elements (but only ``{Y}``, ``{m}``, ``{d}``, ``{H}``, ``{M}``, ``{S}``).
+
+For example,
+
+   logs_filename = {spider}-{Y}{m}{d}.log
+
+If no value is specified, the default value is ``{project}/{spider}/ID.log``
+(where ``ID`` is the job id).
+
+Note: if a custom value for ``logs_filename`` is used then ``jobs_to_keep`` is
+no longer applicable. Scrapyd will not delete old log files.
+
 .. _items_dir:
 
 items_dir

--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from urlparse import urlparse, urlunparse
 
@@ -12,6 +13,7 @@ class Environment(object):
     def __init__(self, config, initenv=os.environ):
         self.dbs_dir = config.get('dbs_dir', 'dbs')
         self.logs_dir = config.get('logs_dir', 'logs')
+        self.logs_filename = config.get('logs_filename', '')
         self.items_dir = config.get('items_dir', 'items')
         self.jobs_to_keep = config.getint('jobs_to_keep', 5)
         if config.cp.has_section('settings'):
@@ -30,10 +32,38 @@ class Environment(object):
         if project in self.settings:
             env['SCRAPY_SETTINGS_MODULE'] = self.settings[project]
         if self.logs_dir:
-            env['SCRAPY_LOG_FILE'] = self._get_file(message, self.logs_dir, 'log')
+            env['SCRAPY_LOG_FILE'] = self._get_log_file(message)
         if self.items_dir:
             env['SCRAPY_FEED_URI'] = self._get_feed_uri(message, 'jl')
         return env
+
+    def _get_log_file(self, message):
+        """Combine the logs_dir and logs_filename config items, and substitute
+        any variables in logs_filename to get the full filename of the log file
+        """
+        if not self.logs_filename:
+            # if no filename specified, fall back on the default.
+            return self._get_file(message, self.logs_dir, 'log')
+
+        now = datetime.datetime.now()
+        format_args = {}
+        format_args['project'] = message['_project']
+        format_args['spider'] = message['_spider']
+        format_args['Y'] = now.year
+        format_args['m'] = now.month
+        format_args['d'] = now.day
+        format_args['H'] = now.hour
+        format_args['M'] = now.minute
+        format_args['S'] = now.second
+        filename = self.logs_filename.format(**format_args)
+
+        full_filename = os.path.join(self.logs_dir, filename)
+
+        containing_dir = os.path.dirname(full_filename)
+        if not os.path.exists(containing_dir):
+            os.makedirs(containing_dir)
+
+        return full_filename
 
     def _get_feed_uri(self, message, ext):
         url = urlparse(self.items_dir)

--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -59,9 +59,9 @@ class Environment(object):
 
         full_filename = os.path.join(self.logs_dir, filename)
 
-        containing_dir = os.path.dirname(full_filename)
-        if not os.path.exists(containing_dir):
-            os.makedirs(containing_dir)
+        log_dir = os.path.dirname(full_filename)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
 
         return full_filename
 

--- a/scrapyd/tests/test_environ.py
+++ b/scrapyd/tests/test_environ.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 
 from twisted.trial import unittest
@@ -43,3 +44,13 @@ class EnvironmentTest(unittest.TestCase):
         env = environ.get_environment(msg, slot)
         self.failUnless('SCRAPY_FEED_URI' not in env)
         self.failUnless('SCRAPY_LOG_FILE' not in env)
+
+    def test_get_environment_with_logfile(self):
+        config = Config(values={'items_dir': '', 'logs_dir': '.', 'logs_filename': '{project}-{spider}-{Y}{m}{d}T{H}{M}{S}'})
+        msg = {'_project': 'mybot', '_spider': 'myspider', '_job': 'ID'}
+        slot = 3
+        environ = Environment(config, initenv={})
+        now = datetime.datetime.now()
+        env = environ.get_environment(msg, slot)
+        expected_logfilename = now.strftime("mybot-spider-%Y%m%dT%H%M%S")
+        self.assert_(env['SCRAPY_LOG_FILE'], expected_logfilename)


### PR DESCRIPTION
Note that if logs_filename is used, then the deleting of old log files
will not happen. This is because the log file could be anything.
So we can't know which files 'belong' to which spider, and thus we can't
sort and delete old ones.
Perhaps this is acceptable (anyone who wants to control the log_filename
will have to manage their own log directory).