### PR TITLE
Use w3lib to generate feed uris.

### DIFF
--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -1,6 +1,7 @@
 import os
 from urlparse import urlparse, urlunparse
 
+from w3lib.url import path_to_file_uri
 from zope.interface import implements
 
 from .interfaces import IEnvironment
@@ -38,7 +39,7 @@ class Environment(object):
     def _get_feed_uri(self, message, ext):
         url = urlparse(self.items_dir)
         if url.scheme.lower() in ['', 'file']:
-            return 'file://' + self._get_file(message, url.path, ext)
+            return path_to_file_uri(self._get_file(message, url.path, ext))
         return urlunparse((url.scheme,
                            url.netloc,
                            '/'.join([url.path,

--- a/scrapyd/tests/test_environ.py
+++ b/scrapyd/tests/test_environ.py
@@ -30,6 +30,7 @@ class EnvironmentTest(unittest.TestCase):
         self.assertEqual(env['SCRAPY_SPIDER'], 'myspider')
         self.assertEqual(env['SCRAPY_JOB'], 'ID')
         self.assert_(env['SCRAPY_LOG_FILE'].endswith(os.path.join('mybot', 'myspider', 'ID.log')))
+        self.assert_(env['SCRAPY_FEED_URI'].startswith('file://{}'.format(os.getcwd())))
         self.assert_(env['SCRAPY_FEED_URI'].endswith(os.path.join('mybot', 'myspider', 'ID.jl')))
         self.failIf('SCRAPY_SETTINGS_MODULE' in env)
 


### PR DESCRIPTION
The file path feed uri generation was producing invalid relative feed:
uris.  w3lib has a method for generating qualified feed uris, so I used
that here.

Example:
The feed path "items/1/spider/hash.jl" would be converted to feed uri
"file://items/1/spider/hash.jl", which actually represents path
"/1/spider/hash.jl".
