### PR TITLE
Update api.rst

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -53,6 +53,9 @@ Example request passing a spider argument (``arg1``) and a setting
 
     $ curl http://localhost:6800/schedule.json -d project=myproject -d spider=somespider -d setting=DOWNLOAD_DELAY=2 -d arg1=val1
 
+.. note:: Spiders scheduled with scrapyd should allow for an arbitrary number of keyword arguments
+          as scrapyd sends internally generated spider arguments to the spider being scheduled
+
 .. _cancel.json:
 
 cancel.json


### PR DESCRIPTION
added a note to schedule.json that spiders should allow for an arbitrary number of keywords arguments to work properly with scrapyd