### PR TITLE
Accept override jobid with default of UUID in webservice.py

### DIFF
--- a/scrapyd/webservice.py
+++ b/scrapyd/webservice.py
@@ -34,7 +34,7 @@ class Schedule(WsResource):
         if not spider in spiders:
             return {"status": "error", "message": "spider '%s' not found" % spider}
         args['settings'] = settings
-        jobid = uuid.uuid1().hex
+        jobid = args.pop('jobid', uuid.uuid1().hex)
         args['_job'] = jobid
         self.root.scheduler.schedule(project, spider, **args)
         return {"node_name": self.root.nodename, "status": "ok", "jobid": jobid}


### PR DESCRIPTION
I've been using Scrapyd in production for months now, and this was a very useful feature for us, so viewing a listing of the jobs online was much more human-friendly, and the jobid's were also used for tracking the generated log messages.