### PR TITLE
config option for website root class

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -113,6 +113,16 @@ and services.
 
 For more info see `Twisted Application Framework`_
 
+.. _webroot:
+
+webroot
+-------
+
+A twisted web resource that represents the interface to scrapyd.
+Scrapyd includes an interface with a website to provide simple monitoring
+and access to the application's webresources.
+This setting must provide the root class of the twisted web resource.
+
 node_name
 ---------
 

--- a/scrapyd/app.py
+++ b/scrapyd/app.py
@@ -10,7 +10,6 @@ from .eggstorage import FilesystemEggStorage
 from .scheduler import SpiderScheduler
 from .poller import QueuePoller
 from .environ import Environment
-from .website import Root
 from .config import Config
 
 def application(config):
@@ -33,8 +32,11 @@ def application(config):
     laucls = load_object(laupath)
     launcher = laucls(config, app)
 
+    webpath = config.get('webroot', 'scrapyd.website.Root')
+    webcls = load_object(webpath)
+
     timer = TimerService(poll_interval, poller.poll)
-    webservice = TCPServer(http_port, server.Site(Root(config, app)), interface=bind_address)
+    webservice = TCPServer(http_port, server.Site(webcls(config, app)), interface=bind_address)
     log.msg(format="Scrapyd web console available at http://%(bind_address)s:%(http_port)s/",
             bind_address=bind_address, http_port=http_port)
 

--- a/scrapyd/default_scrapyd.conf
+++ b/scrapyd/default_scrapyd.conf
@@ -13,6 +13,7 @@ debug       = off
 runner      = scrapyd.runner
 application = scrapyd.app.application
 launcher    = scrapyd.launcher.Launcher
+webroot     = scrapyd.website.Root
 
 [services]
 schedule.json     = scrapyd.webservice.Schedule


### PR DESCRIPTION
Make the Root website class configurable in `scrapyd.conf`

Use case:
Allow overriding the website class
without modifying the twisted application itself.
Although it can be done from the app,
there are several pull requests
demonstrating that people mostly focus on the website
rather than the app.