### PR TITLE
Doc fixes for <things>_to_keep

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -88,8 +88,9 @@ jobs_to_keep
 
 .. versionadded:: 0.15
 
-The number of finished jobs to keep per spider. Defaults to ``5``. This
-includes logs and items.
+The number of finished jobs to keep per spider.
+Defaults to ``5``.
+This refers to logs and items.
 
 This setting was named ``logs_to_keep`` in previous versions.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -94,6 +94,17 @@ This refers to logs and items.
 
 This setting was named ``logs_to_keep`` in previous versions.
 
+.. _finished_to_keep:
+
+finished_to_keep
+----------------
+
+.. versionadded:: 0.14
+
+The number of finished processes to keep in the launcher.
+Defaults to ``100``.
+This only reflects on the website /jobs endpoint and relevant json webservices.
+
 poll_interval
 -------------
 


### PR DESCRIPTION
`finished_to_keep` was missing from documentation
and since it can be very easily confused with `jobs_to_keep`
I added a clarification to it to.