### PR TITLE
[doc update] Scrapy 0.25 breaks ScrapyD

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -40,9 +40,13 @@ Installing Scrapyd in Ubuntu
 
 Scrapyd comes with official Ubuntu packages ready to use in your Ubuntu
 servers. They are shipped in the same APT repos of Scrapy, which can be added
-as described in `Scrapy Ubuntu packages`_. Once you have added the Scrapy APT
-repos, you can install Scrapyd with ``apt-get``::
+as described in `Scrapy Ubuntu packages`_.
 
+Note that ScrapyD only works with versions of Scrapy up to 0.24, version 0.25 breaks ScrapyD, so you should install a specific version separately as the automatic dependencies will otherwise install the latest (incompatible) version.
+
+Once you have added the Scrapy APT repos, you can install Scrapyd with ``apt-get``::
+
+    apt-get install scrapy-0.24
     apt-get install scrapyd
 
 This will install Scrapyd in your Ubuntu server creating a ``scrapy`` user


### PR DESCRIPTION
As explained on IRC, I've had multiple feedbacks from users having issues since recently with ScrapyD, so I did a few investigations on a blank Ubuntu 14.04 machine with the official scrapinghub repository and here are the results.

Just installing with `apt-get scrapyd` results in installing the scrapy package together as a dependency, which is an alias of scrapy-0.25 and has been changed in ways that break ScrapyD (the install does not say so, but it crashes as soon as it is started saying scrapy.utils.txweb is missing).

So I tried one by one to counter-install scrapy-0.18 to scrapy-0.24 and restart scrapyd: it works in each case. scrapy-0.25 is clearly the culprit probably due to some heavy refactoring.

Therefore I'm proposing this documentation update so that users can easily understand and bypass the problem.

But a better fix would definitely be to update the ScrapyD package and make it depend on scrapy-0.24 rather than scrapy, or even better to backport the missing old code in a new version scrapy-0.26.