### PR TITLE
Forgotten job placeholder in the 'logs_filename' setting

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -71,16 +71,15 @@ storing logs set this option empty, like this::
 logs_filename
 -------------
 
-The filename (appended to ``logs_dir``) to use for the crawl. ``{project}``
-and ``{spider}`` placeholders will be substituted, as will certain datetime
-elements (but only ``{Y}``, ``{m}``, ``{d}``, ``{H}``, ``{M}``, ``{S}``).
+The filename (appended to ``logs_dir``) to use for the crawl. ``{project}``,
+``{spider}`` and ``{job}`` placeholders will be substituted, as will certain
+datetime elements (but only ``{Y}``, ``{m}``, ``{d}``, ``{H}``, ``{M}``, ``{S}``).
 
 For example,
 
    logs_filename = {spider}-{Y}{m}{d}.log
 
-If no value is specified, the default value is ``{project}/{spider}/ID.log``
-(where ``ID`` is the job id).
+If no value is specified, the default value is ``{project}/{spider}/{job}.log``.
 
 Note: if a custom value for ``logs_filename`` is used then ``jobs_to_keep`` is
 no longer applicable. Scrapyd will not delete old log files.

--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -50,6 +50,7 @@ class Environment(object):
         format_args = {}
         format_args['project'] = message['_project']
         format_args['spider'] = message['_spider']
+        format_args['job'] = message['_job']
         format_args['Y'] = now.year
         format_args['m'] = now.month
         format_args['d'] = now.day

--- a/scrapyd/tests/test_environ.py
+++ b/scrapyd/tests/test_environ.py
@@ -48,7 +48,7 @@ class EnvironmentTest(unittest.TestCase):
         self.failUnless('SCRAPY_LOG_FILE' not in env)
 
     def test_get_environment_with_logfile(self):
-        config = Config(values={'items_dir': '', 'logs_dir': '.', 'logs_filename': '{project}-{spider}-{Y}{m}{d}T{H}{M}{S}'})
+        config = Config(values={'items_dir': '', 'logs_dir': '.', 'logs_filename': '{project}-{spider}-{job}-{Y}{m}{d}T{H}{M}{S}'})
         msg = {'_project': 'mybot', '_spider': 'myspider', '_job': 'ID'}
         slot = 3
         environ = Environment(config, initenv={})


### PR DESCRIPTION
Added job placeholder {job} into the 'logs_filename' setting.