### PR TITLE
Indicate that wheels are only python 2.7 compatible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+python-tag=py27


### PR DESCRIPTION
See https://wheel.readthedocs.org/en/latest/#defining-the-python-version