### PR TITLE
Add Python 3.4 builds in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,17 @@ matrix:
           env: BUILDENV=precise
         - python: "2.7"
           env: BUILDENV=latest
+        - python: "3.4"
+          env: BUILDENV=latest
         - python: "pypy"
           env: BUILDENV=latest
+
     allow_failures:
         - python: "pypy"
           env: BUILDENV=latest
+        - python: "3.4"
+          env: BUILDENV=latest
+
 install:
     - pip install -r .travis/requirements-$BUILDENV.txt
     - pip install .


### PR DESCRIPTION
Add Python 3.4 builds to Travis CI but allow the tests to fail.
This is in preparation of gradually porting scrapyd to Python 3.
