### PR TITLE
Move priority setting to schedule.json

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -67,6 +67,7 @@ Schedule a spider run (also known as a job), returning the job id.
   * ``spider`` (string, required) - the spider name
   * ``setting`` (string, optional) - a Scrapy setting to use when running the spider
   * ``jobid`` (string, optional) - a job id used to identify the job, overrides the default generated UUID
+  * ``priority`` (float, optional) - priority for this project's spider queue — 0 by default
   * ``_version`` (string, optional) - the version of the project to use
   * any other parameter is passed as spider argument
 

--- a/scrapyd/interfaces.py
+++ b/scrapyd/interfaces.py
@@ -49,7 +49,7 @@ class IPoller(Interface):
 
 class ISpiderQueue(Interface):
 
-    def add(name, **spider_args):
+    def add(name, priority, **spider_args):
         """Add a spider to the queue given its name a some spider arguments.
 
         This method can return a deferred. """
@@ -87,7 +87,7 @@ class ISpiderQueue(Interface):
 class ISpiderScheduler(Interface):
     """A component to schedule spider runs"""
 
-    def schedule(project, spider_name, **spider_args):
+    def schedule(project, spider_name, priority, **spider_args):
         """Schedule a spider for the given project"""
 
     def list_projects():

--- a/scrapyd/scheduler.py
+++ b/scrapyd/scheduler.py
@@ -10,9 +10,9 @@ class SpiderScheduler(object):
         self.config = config
         self.update_projects()
 
-    def schedule(self, project, spider_name, **spider_args):
+    def schedule(self, project, spider_name, priority, **spider_args):
         q = self.queues[project]
-        q.add(spider_name, **spider_args)
+        q.add(spider_name, priority, **spider_args)
 
     def list_projects(self):
         return self.queues.keys()

--- a/scrapyd/scheduler.py
+++ b/scrapyd/scheduler.py
@@ -10,9 +10,10 @@ class SpiderScheduler(object):
         self.config = config
         self.update_projects()
 
-    def schedule(self, project, spider_name, priority, **spider_args):
+    def schedule(self, project, spider_name, priority=0.0, **spider_args):
         q = self.queues[project]
-        q.add(spider_name, priority, **spider_args)
+        # priority passed as kw for compat w/ custom queue. TODO use pos in 1.4
+        q.add(spider_name, priority=priority, **spider_args)
 
     def list_projects(self):
         return self.queues.keys()

--- a/scrapyd/spiderqueue.py
+++ b/scrapyd/spiderqueue.py
@@ -10,10 +10,9 @@ class SqliteSpiderQueue(object):
     def __init__(self, database=None, table='spider_queue'):
         self.q = JsonSqlitePriorityQueue(database, table)
 
-    def add(self, name, **spider_args):
+    def add(self, name, priority, **spider_args):
         d = spider_args.copy()
         d['name'] = name
-        priority = float(d.pop('priority', 0))
         self.q.put(d, priority)
 
     def pop(self):

--- a/scrapyd/spiderqueue.py
+++ b/scrapyd/spiderqueue.py
@@ -10,10 +10,10 @@ class SqliteSpiderQueue(object):
     def __init__(self, database=None, table='spider_queue'):
         self.q = JsonSqlitePriorityQueue(database, table)
 
-    def add(self, name, priority, **spider_args):
+    def add(self, name, priority=0.0, **spider_args):
         d = spider_args.copy()
         d['name'] = name
-        self.q.put(d, priority)
+        self.q.put(d, priority=priority)
 
     def pop(self):
         return self.q.pop()

--- a/scrapyd/tests/test_poller.py
+++ b/scrapyd/tests/test_poller.py
@@ -30,8 +30,9 @@ class QueuePollerTest(unittest.TestCase):
     def test_poll_next(self):
         cfg = {'mybot1': 'spider1',
                'mybot2': 'spider2'}
+        priority = 0
         for prj, spd in cfg.items():
-            self.queues[prj].add(spd)
+            self.queues[prj].add(spd, priority)
 
         d1 = self.poller.next()
         d2 = self.poller.next()

--- a/scrapyd/tests/test_scheduler.py
+++ b/scrapyd/tests/test_scheduler.py
@@ -34,11 +34,12 @@ class SpiderSchedulerTest(unittest.TestCase):
         self.assertEqual(sorted(self.sched.list_projects()), sorted(['mybot1', 'mybot2', 'mybot3']))
 
     def test_schedule(self):
-        q = self.queues['mybot1']
-        self.failIf(q.count())
-        self.sched.schedule('mybot1', 'myspider1', a='b')
-        self.sched.schedule('mybot2', 'myspider2', c='d')
-        self.assertEqual(q.pop(), {'name': 'myspider1', 'a': 'b'})
-        q = self.queues['mybot2']
-        self.assertEqual(q.pop(), {'name': 'myspider2', 'c': 'd'})
+        q1, q2 = self.queues['mybot1'], self.queues['mybot2']
+        self.failIf(q1.count())
+        self.sched.schedule('mybot1', 'myspider1', 2, a='b')
+        self.sched.schedule('mybot2', 'myspider2', 1, c='d')
+        self.sched.schedule('mybot2', 'myspider3', 10, e='f')
+        self.assertEqual(q1.pop(), {'name': 'myspider1', 'a': 'b'})
+        self.assertEqual(q2.pop(), {'name': 'myspider3', 'e': 'f'})
+        self.assertEqual(q2.pop(), {'name': 'myspider2', 'c': 'd'})
 

--- a/scrapyd/tests/test_spiderqueue.py
+++ b/scrapyd/tests/test_spiderqueue.py
@@ -13,6 +13,7 @@ class SpiderQueueTest(unittest.TestCase):
     def setUp(self):
         self.q = spiderqueue.SqliteSpiderQueue(':memory:')
         self.name = 'spider1'
+        self.priority = 5
         self.args = {
             'arg1': 'val1',
             'arg2': 2,
@@ -30,7 +31,7 @@ class SpiderQueueTest(unittest.TestCase):
         c = yield maybeDeferred(self.q.count)
         self.assertEqual(c, 0)
 
-        yield maybeDeferred(self.q.add, self.name, **self.args)
+        yield maybeDeferred(self.q.add, self.name, self.priority, **self.args)
 
         c = yield maybeDeferred(self.q.count)
         self.assertEqual(c, 1)
@@ -46,16 +47,16 @@ class SpiderQueueTest(unittest.TestCase):
         l = yield maybeDeferred(self.q.list)
         self.assertEqual(l, [])
 
-        yield maybeDeferred(self.q.add, self.name, **self.args)
-        yield maybeDeferred(self.q.add, self.name, **self.args)
+        yield maybeDeferred(self.q.add, self.name, self.priority, **self.args)
+        yield maybeDeferred(self.q.add, self.name, self.priority, **self.args)
 
         l = yield maybeDeferred(self.q.list)
         self.assertEqual(l, [self.msg, self.msg])
 
     @inlineCallbacks
     def test_clear(self):
-        yield maybeDeferred(self.q.add, self.name, **self.args)
-        yield maybeDeferred(self.q.add, self.name, **self.args)
+        yield maybeDeferred(self.q.add, self.name, self.priority, **self.args)
+        yield maybeDeferred(self.q.add, self.name, self.priority, **self.args)
 
         c = yield maybeDeferred(self.q.count)
         self.assertEqual(c, 2)

--- a/scrapyd/webservice.py
+++ b/scrapyd/webservice.py
@@ -53,7 +53,7 @@ class Schedule(WsResource):
         args['settings'] = settings
         jobid = args.pop('jobid', uuid.uuid1().hex)
         args['_job'] = jobid
-        self.root.scheduler.schedule(project, spider, priority, **args)
+        self.root.scheduler.schedule(project, spider, priority=priority, **args)
         return {"node_name": self.root.nodename, "status": "ok", "jobid": jobid}
 
 class Cancel(WsResource):

--- a/scrapyd/webservice.py
+++ b/scrapyd/webservice.py
@@ -46,13 +46,14 @@ class Schedule(WsResource):
         project = args.pop('project')
         spider = args.pop('spider')
         version = args.get('_version', '')
+        priority = float(args.pop('priority', 0))
         spiders = get_spider_list(project, version=version)
         if not spider in spiders:
             return {"status": "error", "message": "spider '%s' not found" % spider}
         args['settings'] = settings
         jobid = args.pop('jobid', uuid.uuid1().hex)
         args['_job'] = jobid
-        self.root.scheduler.schedule(project, spider, **args)
+        self.root.scheduler.schedule(project, spider, priority, **args)
         return {"node_name": self.root.nodename, "status": "ok", "jobid": jobid}
 
 class Cancel(WsResource):


### PR DESCRIPTION
Continued from https://github.com/scrapy/scrapyd/issues/144#issuecomment-218963899

The arguments passed from component to component contain arguments addressed to different components, arguments addressed to the crawl process all in a single dictionary. The components shouldn't be poping keys from the dictionary containing the crawl arguments.

Priorities are of interest to schedulers and queues, not processes.
That's why I make the setting a positional argument in their method calls.