### PR TITLE
Deprecate alternative sqlite backed queues/dictionaries

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -11,6 +11,16 @@ The highlight of this release is the long-awaited Python 3 support.
 The new scrapy requirement is version 1.0 or higher.
 Python 2.6 is no longer supported by scrapyd.
 
+Some unused sqlite utilities in are now deprecated
+and will be removed from a later scrapyd release.
+Instantiating them or subclassing from them
+will trigger a deprecation warning.
+These are located under ``scrapyd.sqlite``:
+- SqliteDict
+- SqlitePickleDict
+- SqlitePriorityQueue
+- PickleSqlitePriorityQueue
+
 Added
 ~~~~~
 

--- a/scrapyd/_deprecate.py
+++ b/scrapyd/_deprecate.py
@@ -17,7 +17,7 @@ class WarningMeta(type):
         if offending_classes:
             warnings.warn(
                 '%r inherits from %r which %s deprecated'
-                ' and will be removed from a later scrapyd version'
+                ' and will be removed from a later scrapyd release'
                 % (cls, offending_classes,
                    ['is', 'are'][min(2, len(offending_classes))-1]),
                 ScrapydDeprecationWarning,
@@ -32,7 +32,7 @@ def deprecate_class(cls):
         if type(b) not in WarningMeta2.__bases__:
             WarningMeta2.__bases__ += (type(b),)
     def new_init(*args, **kwargs):
-        warnings.warn('%r will be removed from a later scrapyd version' % cls,
+        warnings.warn('%r will be removed from a later scrapyd release' % cls,
                       ScrapydDeprecationWarning)
         return cls.__init__(*args, **kwargs)
     return WarningMeta2(cls.__name__, (cls,), {'__init__': new_init})

--- a/scrapyd/_deprecate.py
+++ b/scrapyd/_deprecate.py
@@ -26,14 +26,9 @@ class WarningMeta(type):
 
 
 def deprecate_class(cls):
-    base_metaclasses = set(type(b) for b in cls.__bases__) | {WarningMeta}
     class WarningMeta2(WarningMeta):
         pass
-    for b in base_metaclasses:
-        if b not in WarningMeta2.__bases__:
-            WarningMeta2.__bases__ += (b,)
-    #WarningMeta2 = type('WarningMeta', tuple(base_metaclasses), {})
-
-    class cls2(cls):
-        __metaclass__ = WarningMeta2
-    return cls2
+    for b in cls.__bases__:
+        if type(b) not in WarningMeta2.__bases__:
+            WarningMeta2.__bases__ += (type(b),)
+    return WarningMeta2(cls.__name__, (cls,), {})

--- a/scrapyd/_deprecate.py
+++ b/scrapyd/_deprecate.py
@@ -11,7 +11,9 @@ class ScrapydDeprecationWarning(Warning):
 
 class WarningMeta(type):
     def __init__(cls, name, bases, clsdict):
-        offending_classes = tuple(c for c in bases if isinstance(c, WarningMeta))
+        offending_wrapper_classes = tuple(c.__bases__ for c in bases
+                                          if isinstance(c, WarningMeta))
+        offending_classes = tuple(c for c, in offending_wrapper_classes)
         if offending_classes:
             warnings.warn(
                 '%r inherits from %r which %s deprecated'

--- a/scrapyd/_deprecate.py
+++ b/scrapyd/_deprecate.py
@@ -1,0 +1,37 @@
+import warnings
+import inspect
+
+
+class ScrapydDeprecationWarning(Warning):
+    """Warning category for deprecated features, since the default
+    DeprecationWarning is silenced on Python 2.7+
+    """
+    pass
+
+
+class WarningMeta(type):
+    def __init__(cls, name, bases, clsdict):
+        offending_classes = tuple(c for c in bases if isinstance(c, WarningMeta))
+        if offending_classes:
+            warnings.warn(
+                '%r inherits from %r which %s deprecated'
+                ' and will be removed from a later scrapyd version'
+                % (cls, offending_classes,
+                   ['is', 'are'][min(2, len(offending_classes))-1]),
+                ScrapydDeprecationWarning,
+            )
+        super(WarningMeta, cls).__init__(name, bases, clsdict)
+
+
+def deprecate_class(cls):
+    base_metaclasses = set(type(b) for b in cls.__bases__) | {WarningMeta}
+    class WarningMeta2(WarningMeta):
+        pass
+    for b in base_metaclasses:
+        if b not in WarningMeta2.__bases__:
+            WarningMeta2.__bases__ += (b,)
+    #WarningMeta2 = type('WarningMeta', tuple(base_metaclasses), {})
+
+    class cls2(cls):
+        __metaclass__ = WarningMeta2
+    return cls2

--- a/scrapyd/_deprecate.py
+++ b/scrapyd/_deprecate.py
@@ -31,4 +31,8 @@ def deprecate_class(cls):
     for b in cls.__bases__:
         if type(b) not in WarningMeta2.__bases__:
             WarningMeta2.__bases__ += (type(b),)
-    return WarningMeta2(cls.__name__, (cls,), {})
+    def new_init(*args, **kwargs):
+        warnings.warn('%r will be removed from a later scrapyd version' % cls,
+                      ScrapydDeprecationWarning)
+        return cls.__init__(*args, **kwargs)
+    return WarningMeta2(cls.__name__, (cls,), {'__init__': new_init})

--- a/scrapyd/sqlite.py
+++ b/scrapyd/sqlite.py
@@ -11,6 +11,9 @@ except ImportError:
 import six
 
 
+from ._deprecate import deprecate_class
+
+
 class JsonSqliteDict(MutableMapping):
     """SQLite-backed dictionary"""
 
@@ -79,6 +82,7 @@ class JsonSqliteDict(MutableMapping):
         return json.loads(bytes(obj).decode('ascii'))
 
 
+@deprecate_class
 class PickleSqliteDict(JsonSqliteDict):
 
     def encode(self, obj):
@@ -88,6 +92,7 @@ class PickleSqliteDict(JsonSqliteDict):
         return pickle.loads(bytes(obj))
 
 
+@deprecate_class
 class SqliteDict(JsonSqliteDict):
 
     def encode(self, obj):
@@ -166,6 +171,7 @@ class JsonSqlitePriorityQueue(object):
         return json.loads(bytes(text).decode('ascii'))
 
 
+@deprecate_class
 class PickleSqlitePriorityQueue(JsonSqlitePriorityQueue):
 
     def encode(self, obj):
@@ -175,6 +181,7 @@ class PickleSqlitePriorityQueue(JsonSqlitePriorityQueue):
         return pickle.loads(bytes(obj))
 
 
+@deprecate_class
 class SqlitePriorityQueue(JsonSqlitePriorityQueue):
 
     def encode(self, obj):

--- a/scrapyd/sqlite.py
+++ b/scrapyd/sqlite.py
@@ -11,7 +11,7 @@ except ImportError:
 import six
 
 
-class SqliteDict(MutableMapping):
+class JsonSqliteDict(MutableMapping):
     """SQLite-backed dictionary"""
 
     def __init__(self, database=None, table="dict"):
@@ -73,13 +73,13 @@ class SqliteDict(MutableMapping):
         return list(self.iteritems())
 
     def encode(self, obj):
-        return obj
+        return sqlite3.Binary(json.dumps(obj).encode('ascii'))
 
     def decode(self, obj):
-        return obj
+        return json.loads(bytes(obj).decode('ascii'))
 
 
-class PickleSqliteDict(SqliteDict):
+class PickleSqliteDict(JsonSqliteDict):
 
     def encode(self, obj):
         return sqlite3.Binary(pickle.dumps(obj, protocol=2))
@@ -88,16 +88,16 @@ class PickleSqliteDict(SqliteDict):
         return pickle.loads(bytes(obj))
 
 
-class JsonSqliteDict(SqliteDict):
+class SqliteDict(JsonSqliteDict):
 
     def encode(self, obj):
-        return sqlite3.Binary(json.dumps(obj).encode('ascii'))
+        return obj
 
     def decode(self, obj):
-        return json.loads(bytes(obj).decode('ascii'))
+        return obj
 
 
-class SqlitePriorityQueue(object):
+class JsonSqlitePriorityQueue(object):
     """SQLite priority queue. It relies on SQLite concurrency support for
     providing atomic inter-process operations.
     """
@@ -160,13 +160,13 @@ class SqlitePriorityQueue(object):
         return ((self.decode(x), y) for x, y in self.conn.execute(q))
 
     def encode(self, obj):
-        return obj
+        return sqlite3.Binary(json.dumps(obj).encode('ascii'))
 
     def decode(self, text):
-        return text
+        return json.loads(bytes(text).decode('ascii'))
 
 
-class PickleSqlitePriorityQueue(SqlitePriorityQueue):
+class PickleSqlitePriorityQueue(JsonSqlitePriorityQueue):
 
     def encode(self, obj):
         return sqlite3.Binary(pickle.dumps(obj, protocol=2))
@@ -175,10 +175,10 @@ class PickleSqlitePriorityQueue(SqlitePriorityQueue):
         return pickle.loads(bytes(obj))
 
 
-class JsonSqlitePriorityQueue(SqlitePriorityQueue):
+class SqlitePriorityQueue(JsonSqlitePriorityQueue):
 
     def encode(self, obj):
-        return sqlite3.Binary(json.dumps(obj).encode('ascii'))
+        return obj
 
     def decode(self, obj):
-        return json.loads(bytes(obj).decode('ascii'))
+        return obj


### PR DESCRIPTION
_Work in progress because it will conflict with #151_ 

There are 3 alternatives sqlite backed queues and 3 more dictionaries.
I don't think we need so many alternatives in internal components.
In this case I think they are just leftovers from when scrapyd separated from scrapy.

The easiest way to reduce them would be to keep the json variations,
which are used by default, and deprecate the rest.

I have a preference fo the pickling ones because it's easier to handle dates and other objects
but 2 arguments against it convince me to go with the json ones:
- It would make the database more cryptic as it will require unpickling columns to understand their content.
- It's backwards incompatible. A database must not have any rows when restarting scrapyd to upgrade.
