### PR TITLE
Drop logpath formatter

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -68,23 +68,6 @@ storing logs set this option empty, like this::
 
     logs_dir =
 
-logs_filename
--------------
-
-The filename (appended to ``logs_dir``) to use for the crawl. ``{project}``
-and ``{spider}`` placeholders will be substituted, as will certain datetime
-elements (but only ``{Y}``, ``{m}``, ``{d}``, ``{H}``, ``{M}``, ``{S}``).
-
-For example,
-
-   logs_filename = {spider}-{Y}{m}{d}.log
-
-If no value is specified, the default value is ``{project}/{spider}/ID.log``
-(where ``ID`` is the job id).
-
-Note: if a custom value for ``logs_filename`` is used then ``jobs_to_keep`` is
-no longer applicable. Scrapyd will not delete old log files.
-
 .. _items_dir:
 
 items_dir

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -71,15 +71,16 @@ storing logs set this option empty, like this::
 logs_filename
 -------------
 
-The filename (appended to ``logs_dir``) to use for the crawl. ``{project}``,
-``{spider}`` and ``{job}`` placeholders will be substituted, as will certain
-datetime elements (but only ``{Y}``, ``{m}``, ``{d}``, ``{H}``, ``{M}``, ``{S}``).
+The filename (appended to ``logs_dir``) to use for the crawl. ``{project}``
+and ``{spider}`` placeholders will be substituted, as will certain datetime
+elements (but only ``{Y}``, ``{m}``, ``{d}``, ``{H}``, ``{M}``, ``{S}``).
 
 For example,
 
    logs_filename = {spider}-{Y}{m}{d}.log
 
-If no value is specified, the default value is ``{project}/{spider}/{job}.log``.
+If no value is specified, the default value is ``{project}/{spider}/ID.log``
+(where ``ID`` is the job id).
 
 Note: if a custom value for ``logs_filename`` is used then ``jobs_to_keep`` is
 no longer applicable. Scrapyd will not delete old log files.

--- a/scrapyd/contrib/logpathws.py
+++ b/scrapyd/contrib/logpathws.py
@@ -1,0 +1,43 @@
+import datetime
+import uuid
+from scrapyd.webservice import WsResource
+from scrapyd.utils import get_spider_list
+
+
+class Schedule(WsResource):
+
+    def render_POST(self, txrequest):
+        settings = txrequest.args.pop('setting', [])
+        settings = dict(x.split('=', 1) for x in settings)
+        args = dict((k, v[0]) for k, v in txrequest.args.items())
+        project = args.pop('project')
+        spider = args.pop('spider')
+        version = args.get('_version', '')
+        spiders = get_spider_list(project, version=version)
+        if not spider in spiders:
+            return {"status": "error", "message": "spider '%s' not found" % spider}
+        args['settings'] = settings
+        jobid = args.pop('jobid', uuid.uuid1().hex)
+        args['_job'] = jobid
+        self.root.scheduler.schedule(project, spider, **args)
+        settings['LOG_FILE'] = self._log_path(self.config.logs_dir,
+                                              self.config.log_filename_fmt,
+                                              # TODO: tie the config object to the webservices? to the website? to the app?
+                                              project, spider, jobid)
+        return {"node_name": self.root.nodename, "status": "ok", "jobid": jobid}
+
+    def _log_path(self, logs_dir, log_filename_fmt, project, spider, jobid):
+
+        now = datetime.datetime.now()
+        format_args = {'project': project, 'spider': spider, 'job': jobid,
+                       'Y': now.year,      'm': now.month,   'd': now.day,
+                       'H': now.hour,      'M': now.minute,  'S': now.second}
+        filename = log_filename_fmt.format(**format_args)
+
+        full_filename = os.path.join(self.logs_dir, filename)
+
+        log_dir = os.path.dirname(full_filename)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+
+        return full_filename

--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -62,9 +62,9 @@ class Environment(object):
 
         full_filename = os.path.join(self.logs_dir, filename)
 
-        log_dir = os.path.dirname(full_filename)
-        if not os.path.exists(log_dir):
-            os.makedirs(log_dir)
+        containing_dir = os.path.dirname(full_filename)
+        if not os.path.exists(containing_dir):
+            os.makedirs(containing_dir)
 
         return full_filename
 

--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -52,7 +52,6 @@ class Environment(object):
         format_args = {}
         format_args['project'] = message['_project']
         format_args['spider'] = message['_spider']
-        format_args['job'] = message['_job']
         format_args['Y'] = now.year
         format_args['m'] = now.month
         format_args['d'] = now.day

--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 from urlparse import urlparse, urlunparse
 
@@ -14,7 +13,6 @@ class Environment(object):
     def __init__(self, config, initenv=os.environ):
         self.dbs_dir = config.get('dbs_dir', 'dbs')
         self.logs_dir = config.get('logs_dir', 'logs')
-        self.logs_filename = config.get('logs_filename', '')
         self.items_dir = config.get('items_dir', '')
         self.jobs_to_keep = config.getint('jobs_to_keep', 5)
         if config.cp.has_section('settings'):
@@ -35,38 +33,10 @@ class Environment(object):
         if project in self.settings:
             env['SCRAPY_SETTINGS_MODULE'] = self.settings[project]
         if self.logs_dir:
-            env['SCRAPY_LOG_FILE'] = self._get_log_file(message)
+            env['SCRAPY_LOG_FILE'] = self._get_file(message, self.logs_dir, 'log')
         if self.items_dir:
             env['SCRAPY_FEED_URI'] = self._get_feed_uri(message, 'jl')
         return env
-
-    def _get_log_file(self, message):
-        """Combine the logs_dir and logs_filename config items, and substitute
-        any variables in logs_filename to get the full filename of the log file
-        """
-        if not self.logs_filename:
-            # if no filename specified, fall back on the default.
-            return self._get_file(message, self.logs_dir, 'log')
-
-        now = datetime.datetime.now()
-        format_args = {}
-        format_args['project'] = message['_project']
-        format_args['spider'] = message['_spider']
-        format_args['Y'] = now.year
-        format_args['m'] = now.month
-        format_args['d'] = now.day
-        format_args['H'] = now.hour
-        format_args['M'] = now.minute
-        format_args['S'] = now.second
-        filename = self.logs_filename.format(**format_args)
-
-        full_filename = os.path.join(self.logs_dir, filename)
-
-        containing_dir = os.path.dirname(full_filename)
-        if not os.path.exists(containing_dir):
-            os.makedirs(containing_dir)
-
-        return full_filename
 
     def _get_feed_uri(self, message, ext):
         url = urlparse(self.items_dir)

--- a/scrapyd/tests/test_environ.py
+++ b/scrapyd/tests/test_environ.py
@@ -48,7 +48,7 @@ class EnvironmentTest(unittest.TestCase):
         self.failUnless('SCRAPY_LOG_FILE' not in env)
 
     def test_get_environment_with_logfile(self):
-        config = Config(values={'items_dir': '', 'logs_dir': '.', 'logs_filename': '{project}-{spider}-{job}-{Y}{m}{d}T{H}{M}{S}'})
+        config = Config(values={'items_dir': '', 'logs_dir': '.', 'logs_filename': '{project}-{spider}-{Y}{m}{d}T{H}{M}{S}'})
         msg = {'_project': 'mybot', '_spider': 'myspider', '_job': 'ID'}
         slot = 3
         environ = Environment(config, initenv={})

--- a/scrapyd/tests/test_environ.py
+++ b/scrapyd/tests/test_environ.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 
 from twisted.trial import unittest
@@ -46,13 +45,3 @@ class EnvironmentTest(unittest.TestCase):
         env = environ.get_environment(msg, slot)
         self.failUnless('SCRAPY_FEED_URI' not in env)
         self.failUnless('SCRAPY_LOG_FILE' not in env)
-
-    def test_get_environment_with_logfile(self):
-        config = Config(values={'items_dir': '', 'logs_dir': '.', 'logs_filename': '{project}-{spider}-{Y}{m}{d}T{H}{M}{S}'})
-        msg = {'_project': 'mybot', '_spider': 'myspider', '_job': 'ID'}
-        slot = 3
-        environ = Environment(config, initenv={})
-        now = datetime.datetime.now()
-        env = environ.get_environment(msg, slot)
-        expected_logfilename = now.strftime("mybot-spider-%Y%m%dT%H%M%S")
-        self.assert_(env['SCRAPY_LOG_FILE'], expected_logfilename)


### PR DESCRIPTION
This reverts all 3 commits related to #28 #71.
I'm trying to move it to a separate webservice
only not to disappoint scrapyd users
who fell for this feature without waiting for its release.

However, to conclude it,
the config object should be permanently tied to one of the components.
I think people who write custom websites and webservices
should have the ability to define their own config keys.
This would enable them to do so but should be on a separate PR.

**P.S. After trying several things, I gave up moving it to a separate webservice.**

Cc: @m-vdb, @sujaymansingh, @decaz 
