### PR TITLE
Don't use Twisted 16.4 (for now) because of removed bin/trial

### DIFF
--- a/reqs/requirements-latest.txt
+++ b/reqs/requirements-latest.txt
@@ -1,2 +1,2 @@
-Scrapy
-twisted
+Scrapy>=1.1
+twisted<16.4

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,7 @@ envlist = py27
 
 [testenv]
 deps =
-    # equivalent to -rreqs/requirements-latest.txt
-    twisted
-    scrapy
+    -rreqs/requirements-latest.txt
     -rreqs/requirements-tests.txt
 
 commands =


### PR DESCRIPTION
`bin/trial` was removed in Twisted 16.4
https://twistedmatrix.com/trac/ticket/8765
Stick to Twisted 16.3.2 for now