### PR TITLE
[tox] Support Twisted>=16.4 which removed bin/trial

### DIFF
--- a/bin/trial
+++ b/bin/trial
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+import os, sys
+
+try:
+    import _preamble
+except ImportError:
+    try:
+        sys.exc_clear()
+    except AttributeError:
+        # exc_clear() (and the requirement for it) has been removed from Py3
+        pass
+
+# begin chdir armor
+sys.path[:] = map(os.path.abspath, sys.path)
+# end chdir armor
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+print(sys.path)
+
+from twisted.scripts.trial import run
+run()

--- a/bin/trial
+++ b/bin/trial
@@ -17,7 +17,6 @@ sys.path[:] = map(os.path.abspath, sys.path)
 # end chdir armor
 
 sys.path.insert(0, os.path.abspath(os.getcwd()))
-print(sys.path)
 
 from twisted.scripts.trial import run
 run()

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,12 @@ envlist = py27
 
 [testenv]
 deps =
-    # equivalent to -rreqs/requirements-latest.txt
-    twisted
-    scrapy
+    -rreqs/requirements-latest.txt
     -rreqs/requirements-tests.txt
 
 commands =
     coverage erase
-    coverage run --branch {envbindir}/trial {posargs:scrapyd}
+    coverage run --branch {toxinidir}/bin/trial {posargs:scrapyd}
     coverage report
 
 [testenv:precise]


### PR DESCRIPTION
Twisted 16.4 removes bin/trial, recommending `python -m twisted.trial`, but I couldn't get it to work for a couple of tests https://travis-ci.org/scrapy/scrapyd/builds/156175309 
I played with some tox config vars but no success (there probably is a way to make it work)

So this PR copies Twisted 16.3.2's bin/trial script into scrapyd to run the tests