### PR TITLE
Lower scrapy 1.1 dependency to 1.0

### DIFF
--- a/scrapyd/sqlite.py
+++ b/scrapyd/sqlite.py
@@ -10,9 +10,6 @@ except ImportError:
     from collections import MutableMapping
 import six
 
-from scrapy.utils.python import to_bytes, to_unicode, to_native_str
-
-
 
 class SqliteDict(MutableMapping):
     """SQLite-backed dictionary"""
@@ -94,10 +91,10 @@ class PickleSqliteDict(SqliteDict):
 class JsonSqliteDict(SqliteDict):
 
     def encode(self, obj):
-        return sqlite3.Binary(to_bytes(json.dumps(obj)))
+        return sqlite3.Binary(json.dumps(obj).encode('ascii'))
 
     def decode(self, obj):
-        return json.loads(to_native_str(bytes(obj)))
+        return json.loads(bytes(obj).decode('ascii'))
 
 
 class SqlitePriorityQueue(object):
@@ -181,7 +178,7 @@ class PickleSqlitePriorityQueue(SqlitePriorityQueue):
 class JsonSqlitePriorityQueue(SqlitePriorityQueue):
 
     def encode(self, obj):
-        return sqlite3.Binary(to_bytes(json.dumps(obj)))
+        return sqlite3.Binary(json.dumps(obj).encode('ascii'))
 
     def decode(self, obj):
-        return json.loads(to_native_str(bytes(obj)))
+        return json.loads(bytes(obj).decode('ascii'))

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup_args = {
 
 
 if using_setuptools:
-    setup_args['install_requires'] = ['Twisted>=8.0', 'Scrapy>=1.1', 'six']
+    setup_args['install_requires'] = ['Twisted>=8.0', 'Scrapy>=1.0', 'six']
     setup_args['entry_points'] = {'console_scripts': [
         'scrapyd = scrapyd.scripts.scrapyd_run:main'
     ]}


### PR DESCRIPTION
An attempt for https://github.com/scrapy/scrapyd/pull/179#issuecomment-243439640

It's hard to verify the return types of all these functions for both pythons
so I did the easy parts in `sqlite.py` and replaced `to_native_str()` in `native_stringify_dict()`