### PR TITLE
[Travis CI] Add auto-deploy to PyPI on master branch tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,5 +53,7 @@ deploy:
     password:
         secure: IuHONsIRm8w54LkmUlZe0X0dFqW2iAjTyqeRyOyVMvHWIPaiydNpX+xipvRArJnswlnzf7/X3CtZw9ZF9ePznCrvG+3Y1SLHutncRbr6IxSQrcRJm+FTF2I2KNEaOkWqoQjO7xbEehpqo6fttHImCNrCzgZw32hCZqeGbDGPGJs=
     on:
+        all_branches: true
         tags: true
         repo: scrapy/scrapyd
+        condition: "$TOXENV == py27 && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+([ab][0-9]+|rc[0-9]+|dev[0-9]+)?$"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,13 @@ notifications:
             - "irc.freenode.org#scrapy"
         use_notice: true
         skip_join: true
+
+deploy:
+    provider: pypi
+    distributions: sdist bdist_wheel
+    user: redapple
+    password:
+        secure: IuHONsIRm8w54LkmUlZe0X0dFqW2iAjTyqeRyOyVMvHWIPaiydNpX+xipvRArJnswlnzf7/X3CtZw9ZF9ePznCrvG+3Y1SLHutncRbr6IxSQrcRJm+FTF2I2KNEaOkWqoQjO7xbEehpqo6fttHImCNrCzgZw32hCZqeGbDGPGJs=
+    on:
+        tags: true
+        repo: scrapy/scrapyd


### PR DESCRIPTION
Reference: https://docs.travis-ci.com/user/deployment/pypi/

Generated with `travis setup pypi`
```
$ travis setup pypi
Detected repository as scrapy/scrapyd, is this correct? |yes| yes
Username: redapple
Password: ****************
release only tagged commits? |yes| 
deploy as wheel file too? |yes| 
Release only from scrapy/scrapyd? |yes| 
Release from travis2pypi-deploy branch? |yes| no
Encrypt Password? |yes| yes
```