### PR TITLE
configurable spider queue class

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -137,6 +137,19 @@ Scrapyd includes an interface with a website to provide simple monitoring
 and access to the application's webresources.
 This setting must provide the root class of the twisted web resource.
 
+.. _spiderqueue:
+
+spiderqueue
+-----------
+
+The per-project spider queues are where the scheduler enqueues crawls
+for the poller to pick.
+You can define a custom spider queue class here
+as long as it implements the ISpiderQueue interface.
+
+Defaults to ``scrapyd.spiderqueue.SqliteSpiderQueue``.
+
+
 node_name
 ---------
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -14,6 +14,7 @@ Python 2.6 is no longer supported by scrapyd.
 Added
 ~~~~~
 
+- Make spider queue class configurable
 - Include run's PID in listjobs webservice.
 - Include full tracebacks from scrapy when failing to get spider list.
   This will lead to more noisy webservice output

--- a/scrapyd/default_scrapyd.conf
+++ b/scrapyd/default_scrapyd.conf
@@ -14,6 +14,7 @@ debug       = off
 runner      = scrapyd.runner
 application = scrapyd.app.application
 launcher    = scrapyd.launcher.Launcher
+spiderqueue = scrapyd.spiderqueue.SqliteSpiderQueue
 webroot     = scrapyd.website.Root
 
 [services]

--- a/scrapyd/utils.py
+++ b/scrapyd/utils.py
@@ -8,8 +8,11 @@ from six.moves.configparser import NoSectionError
 import json
 from twisted.web import resource
 
-from scrapyd.spiderqueue import SqliteSpiderQueue
+from scrapy.utils.misc import load_object
 from scrapyd.config import Config
+
+
+DEFAULT_SPIDERQUEUE = 'scrapyd.spiderqueue.SqliteSpiderQueue'
 
 
 class JsonResource(resource.Resource):
@@ -56,10 +59,11 @@ def get_spider_queues(config):
     dbsdir = config.get('dbs_dir', 'dbs')
     if not os.path.exists(dbsdir):
         os.makedirs(dbsdir)
+    spiderqueue = load_object(config.get('spiderqueue', DEFAULT_SPIDERQUEUE))
     d = {}
     for project in get_project_list(config):
         dbpath = os.path.join(dbsdir, '%s.db' % project)
-        d[project] = SqliteSpiderQueue(dbpath)
+        d[project] = spiderqueue(dbpath)
     return d
 
 def get_project_list(config):


### PR DESCRIPTION
(TODO: doc)
This was once (scrapy<0.14) supported by a scrapy setting.
I have plans for merging the sqlite priority queue into the spider queue
but this change is unlikely to interfere.

Full context: #197 
Cc: @bezkos
