### PR TITLE
Add start/finish time columns to job list

### DIFF
--- a/scrapyd/website.py
+++ b/scrapyd/website.py
@@ -111,7 +111,7 @@ class Jobs(resource.Resource):
         s += "<h1>Jobs</h1>"
         s += "<p><a href='..'>Go back</a></p>"
         s += "<table border='1'>"
-        s += "<tr><th>Project</th><th>Spider</th><th>Job</th><th>PID</th><th>Start</th><th>Finish</th><th>Runtime</th><th>Log</th>"
+        s += "<tr><th>Project</th><th>Spider</th><th>Job</th><th>PID</th><th>Start</th><th>Runtime</th><th>Finish</th><th>Log</th>"
         if self.local_items:
             s += "<th>Items</th>"
             cols = 9
@@ -130,8 +130,8 @@ class Jobs(resource.Resource):
             for a in ['project', 'spider', 'job', 'pid']:
                 s += "<td>%s</td>" % getattr(p, a)
             s += "<td>%s</td>" % p.start_time.replace(microsecond=0)
-            s += "<td></td>"
             s += "<td>%s</td>" % (datetime.now().replace(microsecond=0) - p.start_time.replace(microsecond=0))
+            s += "<td></td>"
             s += "<td><a href='/logs/%s/%s/%s.log'>Log</a></td>" % (p.project, p.spider, p.job)
             if self.local_items:
                 s += "<td><a href='/items/%s/%s/%s.jl'>Items</a></td>" % (p.project, p.spider, p.job)
@@ -143,8 +143,8 @@ class Jobs(resource.Resource):
                 s += "<td>%s</td>" % getattr(p, a)
             s += "<td></td>"
             s += "<td>%s</td>" % p.start_time.replace(microsecond=0)
-            s += "<td>%s</td>" % p.end_time.replace(microsecond=0)
             s += "<td>%s</td>" % (p.end_time.replace(microsecond=0) - p.start_time.replace(microsecond=0))
+            s += "<td>%s</td>" % p.end_time.replace(microsecond=0)
             s += "<td><a href='/logs/%s/%s/%s.log'>Log</a></td>" % (p.project, p.spider, p.job)
             if self.local_items:
                 s += "<td><a href='/items/%s/%s/%s.jl'>Items</a></td>" % (p.project, p.spider, p.job)

--- a/scrapyd/website.py
+++ b/scrapyd/website.py
@@ -105,16 +105,16 @@ class Jobs(resource.Resource):
         self.local_items = local_items
 
     def render(self, txrequest):
-        cols = 6
+        cols = 8
         s = "<html><head><title>Scrapyd</title></head>"
         s += "<body>"
         s += "<h1>Jobs</h1>"
         s += "<p><a href='..'>Go back</a></p>"
         s += "<table border='1'>"
-        s += "<tr><th>Project</th><th>Spider</th><th>Job</th><th>PID</th><th>Runtime</th><th>Log</th>"
+        s += "<tr><th>Project</th><th>Spider</th><th>Job</th><th>PID</th><th>Start</th><th>Finish</th><th>Runtime</th><th>Log</th>"
         if self.local_items:
             s += "<th>Items</th>"
-            cols = 7
+            cols = 9
         s += "</tr>"
         s += "<tr><th colspan='%s' style='background-color: #ddd'>Pending</th></tr>" % cols
         for project, queue in self.root.poller.queues.items():
@@ -129,7 +129,9 @@ class Jobs(resource.Resource):
             s += "<tr>"
             for a in ['project', 'spider', 'job', 'pid']:
                 s += "<td>%s</td>" % getattr(p, a)
-            s += "<td>%s</td>" % (datetime.now() - p.start_time)
+            s += "<td>%s</td>" % p.start_time.replace(microsecond=0)
+            s += "<td></td>"
+            s += "<td>%s</td>" % (datetime.now().replace(microsecond=0) - p.start_time.replace(microsecond=0))
             s += "<td><a href='/logs/%s/%s/%s.log'>Log</a></td>" % (p.project, p.spider, p.job)
             if self.local_items:
                 s += "<td><a href='/items/%s/%s/%s.jl'>Items</a></td>" % (p.project, p.spider, p.job)
@@ -140,7 +142,9 @@ class Jobs(resource.Resource):
             for a in ['project', 'spider', 'job']:
                 s += "<td>%s</td>" % getattr(p, a)
             s += "<td></td>"
-            s += "<td>%s</td>" % (p.end_time - p.start_time)
+            s += "<td>%s</td>" % p.start_time.replace(microsecond=0)
+            s += "<td>%s</td>" % p.end_time.replace(microsecond=0)
+            s += "<td>%s</td>" % (p.end_time.replace(microsecond=0) - p.start_time.replace(microsecond=0))
             s += "<td><a href='/logs/%s/%s/%s.log'>Log</a></td>" % (p.project, p.spider, p.job)
             if self.local_items:
                 s += "<td><a href='/items/%s/%s/%s.jl'>Items</a></td>" % (p.project, p.spider, p.job)


### PR DESCRIPTION
Displaying start/finish time on job list is very handy for schedule checking.

![screen shot 2017-01-14 at 01 06 47](https://cloud.githubusercontent.com/assets/6779585/21938334/de959192-d9f5-11e6-9753-25201ec15868.png)
