### PR TITLE
native string type in exc msg in get_spider_list

### DIFF
--- a/scrapyd/utils.py
+++ b/scrapyd/utils.py
@@ -133,7 +133,9 @@ def get_spider_list(project, runner=None, pythonpath=None, version=''):
     out, err = proc.communicate()
     if proc.returncode:
         msg = err or out or 'unknown error'
-        raise RuntimeError(msg.splitlines()[-1])
+        msg = msg.decode('utf8')
+        msg.splitlines()[-1]
+        raise RuntimeError(msg.encode('unicode_escape') if six.PY2 else msg)
     # FIXME: can we reliably decode as UTF-8?
     # scrapy list does `print(list)`
     tmp = out.decode('utf-8').splitlines();


### PR DESCRIPTION
Exception messages are unicode in py3 and bytes in py2.
If unicode characters are needed in py2, they should be encoded to unicode_escape.

We did this before in scrapy: https://github.com/scrapy/scrapy/pull/952


This is a trivial fix, we can do a fast-forward merge