### PR TITLE
Generate uuid4 job ids instead of uuid1

### DIFF
--- a/scrapyd/webservice.py
+++ b/scrapyd/webservice.py
@@ -50,7 +50,7 @@ class Schedule(WsResource):
         if not spider in spiders:
             return {"status": "error", "message": "spider '%s' not found" % spider}
         args['settings'] = settings
-        jobid = args.pop('jobid', uuid.uuid1().hex)
+        jobid = args.pop('jobid', uuid.uuid4().hex)
         args['_job'] = jobid
         self.root.scheduler.schedule(project, spider, **args)
         return {"node_name": self.root.nodename, "status": "ok", "jobid": jobid}


### PR DESCRIPTION
Changed uuid1 to uuid4 to avoid any chance of collisions, when job id is used as a global job identifier, even if running multiple scrapyd instances, as per issue #214.