### PR TITLE
Native-stringify project and version arguments when deploying

### DIFF
--- a/scrapyd/webservice.py
+++ b/scrapyd/webservice.py
@@ -79,9 +79,10 @@ class Cancel(WsResource):
 class AddVersion(WsResource):
 
     def render_POST(self, txrequest):
-        project = txrequest.args[b'project'][0].decode('utf-8')
-        version = txrequest.args[b'version'][0].decode('utf-8')
-        eggf = BytesIO(txrequest.args[b'egg'][0])
+        eggf = BytesIO(txrequest.args.pop(b'egg')[0])
+        args = native_stringify_dict(copy(txrequest.args), keys_only=False)
+        project = args['project'][0]
+        version = args['version'][0]
         self.root.eggstorage.put(eggf, project, version)
         spiders = get_spider_list(project, version=version)
         self.root.update_projects()


### PR DESCRIPTION
Should fix one case of https://github.com/scrapy/scrapyd/issues/231.
This does not fix the case where [`SCRAPY_PROJECT` is set to a `dict`](https://github.com/scrapy/scrapyd/issues/231#issuecomment-315743172).

I was able to reproduce `exceptions.TypeError: environment can only contain strings` with Miniconda and Python 2.7 on Windows 7. And the problem was Unicode strings for `project` and `version`.

This patch is similar to what @evrn1874 suggests in https://github.com/scrapy/scrapyd/issues/231#issuecomment-326577064 , but it tries to use the same pattern as other `render_POST()`.