### PR TITLE
warning for apt-get install scrapyd on ubuntu

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,6 +38,10 @@ send a pull request on Github.
 Installing Scrapyd in Ubuntu
 ----------------------------
 
+Caution!
+
+These packages are currently not updated and may not work on Ubuntu 16.04 and above.
+
 Scrapyd comes with official Ubuntu packages ready to use in your Ubuntu
 servers. They are shipped in the same APT repos of Scrapy, which can be added
 as described in `Scrapy Ubuntu packages`_. Once you have added the Scrapy APT


### PR DESCRIPTION
As determined over at Scrapy, the apt-get method is based on an outdated package and an install won't work (even if instructions are correctly followed) on Ubuntu 16.04 and above. See https://github.com/scrapy/scrapy/issues/2137 for further information.

I would even suggest to deprecate this part, until the underlying packages have been updated (as done over at the scrapy repo).