### PR TITLE
List all jobs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -172,18 +172,38 @@ Get the list of pending, running and finished jobs of some project.
 * Supported Request Methods: ``GET``
 * Parameters:
 
-  * ``project`` (string, required) - the project name
+  * ``project`` (string, option) - restrict results to project name
 
 Example request::
 
-    $ curl http://localhost:6800/listjobs.json?project=myproject
+    $ curl http://localhost:6800/listjobs.json?project=myproject | python -m json.tool
 
 Example response::
 
-    {"status": "ok",
-     "pending": [{"id": "78391cc0fcaf11e1b0090800272a6d06", "spider": "spider1"}],
-     "running": [{"id": "422e608f9f28cef127b3d5ef93fe9399", "spider": "spider2", "start_time": "2012-09-12 10:14:03.594664"}],
-     "finished": [{"id": "2f16646cfcaf11e1b0090800272a6d06", "spider": "spider3", "start_time": "2012-09-12 10:14:03.594664", "end_time": "2012-09-12 10:24:03.594664"}]}
+    {
+        "status": "ok",
+        "pending": [
+            {
+                "project": "myproject", "spider": "spider1",
+                "id": "78391cc0fcaf11e1b0090800272a6d06"
+            }
+        ],
+        "running": [
+            {
+                "id": "422e608f9f28cef127b3d5ef93fe9399",
+                "project": "myproject", "spider": "spider2",
+                "start_time": "2012-09-12 10:14:03.594664"
+            }
+        ],
+        "finished": [
+            {
+                "id": "2f16646cfcaf11e1b0090800272a6d06",
+                "project": "myproject", "spider": "spider3",
+                "start_time": "2012-09-12 10:14:03.594664",
+                "end_time": "2012-09-12 10:24:03.594664"
+            }
+        ]
+    }
 
 .. note:: All job data is kept in memory and will be reset when the Scrapyd service is restarted. See `issue 12`_.
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,12 @@ Release notes
 -----
 *Unreleased*
 
+Added
+~~~~~
+
+- Make project argument to listjobs.json optional,
+  so that we can easily query for all jobs.
+
 Removed
 ~~~~~~~
 

--- a/scrapyd/webservice.py
+++ b/scrapyd/webservice.py
@@ -118,16 +118,27 @@ class ListJobs(WsResource):
         args = native_stringify_dict(copy(txrequest.args), keys_only=False)
         project = args['project'][0]
         spiders = self.root.launcher.processes.values()
-        running = [{"id": s.job, "spider": s.spider, "pid": s.pid,
-                    "start_time": s.start_time.isoformat(' ')}
-                   for s in spiders if s.project == project]
         queue = self.root.poller.queues[project]
-        pending = [{"id": x["_job"], "spider": x["name"]} for x in queue.list()]
-        finished = [{"id": s.job, "spider": s.spider,
-            "start_time": s.start_time.isoformat(' '),
-            "end_time": s.end_time.isoformat(' ')} for s in self.root.launcher.finished
-            if s.project == project]
-        return {"node_name": self.root.nodename, "status":"ok", "pending": pending, "running": running, "finished": finished}
+        pending = [
+            {"spider": x["name"], "id": x["_job"]}
+            for x in queue.list()
+        ]
+        running = [
+            {
+                "spider": s.spider,
+                "id": s.job, "pid": s.pid,
+                "start_time": s.start_time.isoformat(' '),
+            } for s in spiders if s.project == project
+        ]
+        finished = [
+            {
+                "spider": s.spider, "id": s.job,
+                "start_time": s.start_time.isoformat(' '),
+                "end_time": s.end_time.isoformat(' '),
+            } for s in self.root.launcher.finished if s.project == project
+        ]
+        return {"node_name": self.root.nodename, "status": "ok",
+                "pending": pending, "running": running, "finished": finished}
 
 class DeleteProject(WsResource):
 

--- a/scrapyd/webservice.py
+++ b/scrapyd/webservice.py
@@ -127,14 +127,14 @@ class ListJobs(WsResource):
             {
                 "spider": s.spider,
                 "id": s.job, "pid": s.pid,
-                "start_time": s.start_time.isoformat(' '),
+                "start_time": str(s.start_time),
             } for s in spiders if s.project == project
         ]
         finished = [
             {
                 "spider": s.spider, "id": s.job,
-                "start_time": s.start_time.isoformat(' '),
-                "end_time": s.end_time.isoformat(' '),
+                "start_time": str(s.start_time),
+                "end_time": str(s.end_time)
             } for s in self.root.launcher.finished if s.project == project
         ]
         return {"node_name": self.root.nodename, "status": "ok",


### PR DESCRIPTION
Makes the project argument in the listjobs webservice optional.
Without an arg, it now list jobs from all projects.