### PR TITLE
Avoid using DeferredQueue.pending to fix #327

### DIFF
--- a/scrapyd/poller.py
+++ b/scrapyd/poller.py
@@ -11,11 +11,11 @@ class QueuePoller(object):
     def __init__(self, config):
         self.config = config
         self.update_projects()
-        self.dq = DeferredQueue(size=1)
+        self.dq = DeferredQueue()
 
     @inlineCallbacks
     def poll(self):
-        if self.dq.pending:
+        if not self.dq.waiting:
             return
         for p, q in iteritems(self.queues):
             c = yield maybeDeferred(q.count)


### PR DESCRIPTION
This PR keeps `poller.dq.pending` empty so that all pending jobs
would be shown correctly in the Jobs page, as well as the API of
`listjobs.json` and `daemonstatus.json`.