### PR TITLE
get_project_list() must only look for directories

### DIFF
--- a/scrapyd/utils.py
+++ b/scrapyd/utils.py
@@ -67,14 +67,11 @@ def get_project_list(config):
     the scrapyd.conf [settings] section
     """
     eggs_dir = config.get('eggs_dir', 'eggs')
+    projects = []
     if os.path.exists(eggs_dir):
-        projects = os.listdir(eggs_dir)
-    else:
-        projects = []
-    try:
-        projects += [x[0] for x in config.cp.items('settings')]
-    except NoSectionError:
-        pass
+        projects.extend(d for d in os.listdir(eggs_dir)
+                        if os.path.isdir('%s/%s' % (eggs_dir, d)))
+    projects.extend(x[0] for x in config.items('settings', default=[]))
     return projects
 
 def native_stringify_dict(dct_or_tuples, encoding='utf-8', keys_only=True):


### PR DESCRIPTION
Files in eggs_dir shouldn't be there in the first place
but when they are, they shouldn't be understood as projects.

I was going to write a proper fix for #237
with  checks for directories in the config
but os.path.samefile() got windows support in py3
so I will not bother until 1.4.

A fix for #237 shouldn't resemble this patch at all.