### PR TITLE
Replaced FEED_URI with FEEDS argument

### DIFF
--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -6,6 +6,7 @@ from zope.interface import implementer
 
 from .interfaces import IEnvironment
 
+
 @implementer(IEnvironment)
 class Environment(object):
 
@@ -32,9 +33,13 @@ class Environment(object):
         if project in self.settings:
             env['SCRAPY_SETTINGS_MODULE'] = self.settings[project]
         if self.logs_dir:
-            env['SCRAPY_LOG_FILE'] = self._get_file(message, self.logs_dir, 'log')
+            env['SCRAPY_LOG_FILE'] = self._get_file(
+                message, self.logs_dir, 'log')
         if self.items_dir:
-            env['SCRAPY_FEED_URI'] = self._get_feed_uri(message, 'jl')
+            # env['SCRAPY_FEED_URI'] = self._get_feed_uri(message, 'jl')
+            # use the new FEEDS dictionary
+            env['FEEDS'] = {self._get_feed_uri(message, '.jl'): {
+                'format': 'jsonlines', 'encoding': 'utf8'}}
         return env
 
     def _get_feed_uri(self, message, ext):
@@ -52,12 +57,12 @@ class Environment(object):
                            url.fragment))
 
     def _get_file(self, message, dir, ext):
-        logsdir = os.path.join(dir, message['_project'], \
-            message['_spider'])
+        logsdir = os.path.join(dir, message['_project'],
+                               message['_spider'])
         if not os.path.exists(logsdir):
             os.makedirs(logsdir)
-        to_delete = sorted((os.path.join(logsdir, x) for x in \
-            os.listdir(logsdir)), key=os.path.getmtime)[:-self.jobs_to_keep]
+        to_delete = sorted((os.path.join(logsdir, x) for x in
+                            os.listdir(logsdir)), key=os.path.getmtime)[:-self.jobs_to_keep]
         for x in to_delete:
             os.remove(x)
         return os.path.join(logsdir, "%s.%s" % (message['_job'], ext))

--- a/scrapyd/launcher.py
+++ b/scrapyd/launcher.py
@@ -76,7 +76,8 @@ class ScrapyProcessProtocol(protocol.ProcessProtocol):
         self.end_time = None
         self.env = env
         self.logfile = env.get('SCRAPY_LOG_FILE')
-        self.itemsfile = env.get('SCRAPY_FEED_URI')
+        # self.itemsfile = env.get('SCRAPY_FEED_URI')
+        self.itemsfile = env.get('FEEDS')
         self.deferred = defer.Deferred()
 
     def outReceived(self, data):


### PR DESCRIPTION
Replaced FEED_URI spider argument with the FEEDS argument as the FEED_URI argument is deprecated in scrapy version 2.1.0