### PR TITLE
[setup.py] remove enum-compat

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,7 +13,8 @@ Scrapyd depends on the following libraries, but the installation process
 takes care of installing the missing ones:
 
 * Python 3.6 or above
-* Scrapy 2 or above
+* Scrapy 1.2 or above
+* Twisted 17.9 or above
 
 Installing Scrapyd (generic way)
 --------------------------------

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,9 @@ setup_args = {
 
 if using_setuptools:
     setup_args['install_requires'] = [
-        'Twisted>=8.0',
-        'Scrapy>=2.0',
-        'six',
-        'enum-compat',
+        'Twisted>=17.9',
+        'Scrapy>=1.2.0',
+        'six'
     ]
     setup_args['entry_points'] = {'console_scripts': [
         'scrapyd = scrapyd.scripts.scrapyd_run:main'


### PR DESCRIPTION
it was a requirement for Python 3.4 which we don't need anymore. Also change
required Twisted and Scrapy version to ones that support Python 3.6, versions below
these numbers don't support Python 3.6 which is minimum Python we require now