### PR TITLE
chore: Rename environment variables to avoid spurious Scrapy deprecation warnings

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,6 +3,19 @@
 Release notes
 =============
 
+Unreleased
+----------
+
+Changed
+~~~~~~~
+
+-  Rename environment variables to avoid spurious Scrapy deprecation warnings:
+
+   - ``SCRAPY_EGG_VERSION`` to ``SCRAPYD_EGG_VERSION``
+   - ``SCRAPY_JOB`` to ``SCRAPYD_JOB``
+   - ``SCRAPY_SLOT`` to ``SCRAPYD_SLOT``
+   - ``SCRAPY_SPIDER`` to ``SCRAPYD_SPIDER``
+
 1.3.0
 -----
 *Release date: 2022-01-12*

--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -23,12 +23,12 @@ class Environment(object):
     def get_environment(self, message, slot):
         project = message['_project']
         env = self.initenv.copy()
-        env['SCRAPY_SLOT'] = str(slot)
+        env['SCRAPYD_SLOT'] = str(slot)
         env['SCRAPY_PROJECT'] = project
-        env['SCRAPY_SPIDER'] = message['_spider']
-        env['SCRAPY_JOB'] = message['_job']
+        env['SCRAPYD_SPIDER'] = message['_spider']
+        env['SCRAPYD_JOB'] = message['_job']
         if '_version' in message:
-            env['SCRAPY_EGG_VERSION'] = message['_version']
+            env['SCRAPYD_EGG_VERSION'] = message['_version']
         if project in self.settings:
             env['SCRAPY_SETTINGS_MODULE'] = self.settings[project]
         if self.logs_dir:

--- a/scrapyd/runner.py
+++ b/scrapyd/runner.py
@@ -11,7 +11,7 @@ from scrapyd.eggutils import activate_egg
 
 @contextmanager
 def project_environment(project):
-    eggversion = os.environ.get('SCRAPY_EGG_VERSION', None)
+    eggversion = os.environ.get('SCRAPYD_EGG_VERSION', None)
     config = Config()
     eggstorage_path = config.get(
         'eggstorage', 'scrapyd.eggstorage.FilesystemEggStorage'

--- a/scrapyd/tests/test_environ.py
+++ b/scrapyd/tests/test_environ.py
@@ -26,9 +26,9 @@ class EnvironmentTest(unittest.TestCase):
         slot = 3
         env = self.environ.get_environment(msg, slot)
         self.assertEqual(env['SCRAPY_PROJECT'], 'mybot')
-        self.assertEqual(env['SCRAPY_SLOT'], '3')
-        self.assertEqual(env['SCRAPY_SPIDER'], 'myspider')
-        self.assertEqual(env['SCRAPY_JOB'], 'ID')
+        self.assertEqual(env['SCRAPYD_SLOT'], '3')
+        self.assertEqual(env['SCRAPYD_SPIDER'], 'myspider')
+        self.assertEqual(env['SCRAPYD_JOB'], 'ID')
         self.assert_(env['SCRAPY_LOG_FILE'].endswith(os.path.join('mybot', 'myspider', 'ID.log')))
         if env.get('SCRAPY_FEED_URI'):  # Not compulsory
             self.assert_(env['SCRAPY_FEED_URI'].startswith('file://{}'.format(os.getcwd())))

--- a/scrapyd/utils.py
+++ b/scrapyd/utils.py
@@ -124,7 +124,7 @@ def get_spider_list(project, runner=None, pythonpath=None, version=''):
     if pythonpath:
         env['PYTHONPATH'] = pythonpath
     if version:
-        env['SCRAPY_EGG_VERSION'] = version
+        env['SCRAPYD_EGG_VERSION'] = version
     pargs = [sys.executable, '-m', runner, 'list']
     proc = Popen(pargs, stdout=PIPE, stderr=PIPE, env=env)
     out, err = proc.communicate()


### PR DESCRIPTION
Partially addresses #369