### PR TITLE
Use latest version of Ubuntu

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   tests:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We are using `ubuntu-latest` in others workflows, tests workflow was the only one remaining, this change aim to make workflows standardized across the project.

⚠️ Failing test  on 3.8 version is not related with the change of the runner OS, same change in my branch runned successfully: https://github.com/Laerte/scrapyd/actions/runs/3301381846/jobs/5446816790