### PR TITLE
Remove `six` package dependency

### DIFF
--- a/scrapyd/environ.py
+++ b/scrapyd/environ.py
@@ -1,6 +1,6 @@
 import os
+from urllib.parse import urlparse, urlunparse
 
-from six.moves.urllib.parse import urlparse, urlunparse
 from w3lib.url import path_to_file_uri
 from zope.interface import implementer
 

--- a/scrapyd/poller.py
+++ b/scrapyd/poller.py
@@ -1,4 +1,3 @@
-from six import iteritems
 from twisted.internet.defer import DeferredQueue, inlineCallbacks, maybeDeferred, returnValue
 from zope.interface import implementer
 
@@ -18,7 +17,7 @@ class QueuePoller(object):
     def poll(self):
         if not self.dq.waiting:
             return
-        for p, q in iteritems(self.queues):
+        for p, q in self.queues.items():
             c = yield maybeDeferred(q.count)
             if c:
                 msg = yield maybeDeferred(q.pop)

--- a/scrapyd/tests/test_utils.py
+++ b/scrapyd/tests/test_utils.py
@@ -2,19 +2,12 @@
 import os
 from io import BytesIO
 from pkgutil import get_data
+from subprocess import Popen
+from unittest import mock
 
 import pytest
-import six
-from twisted.trial import unittest
-
-if six.PY2:
-    import mock
-else:
-    from unittest import mock
-
-from subprocess import Popen
-
 from scrapy.utils.test import get_pythonpath
+from twisted.trial import unittest
 
 from scrapyd import get_application
 from scrapyd.interfaces import IEggStorage
@@ -122,7 +115,6 @@ class GetSpiderListTest(unittest.TestCase):
             exc = self.assertRaises(RuntimeError,
                                     get_spider_list, 'mybot3', pythonpath=pypath)
         tb = str(exc).rstrip()
-        tb = tb.decode('unicode_escape') if six.PY2 else tb
         tb_regex = (
             r'Exception: This should break the `scrapy list` command$'
         )

--- a/scrapyd/utils.py
+++ b/scrapyd/utils.py
@@ -3,9 +3,7 @@ import os
 import sys
 from subprocess import PIPE, Popen
 
-import six
 from scrapy.utils.misc import load_object
-from six import iteritems
 from twisted.web import resource
 
 from scrapyd.config import Config
@@ -84,7 +82,7 @@ def native_stringify_dict(dct_or_tuples, encoding='utf-8', keys_only=True):
     dict or a list of tuples, like any dict constructor supports.
     """
     d = {}
-    for k, v in iteritems(dict(dct_or_tuples)):
+    for k, v in dct_or_tuples.items():
         k = _to_native_str(k, encoding)
         if not keys_only:
             if isinstance(v, dict):
@@ -137,7 +135,7 @@ def get_spider_list(project, runner=None, pythonpath=None, version=''):
     if proc.returncode:
         msg = err or out or ''
         msg = msg.decode('utf8')
-        raise RuntimeError(msg.encode('unicode_escape') if six.PY2 else msg)
+        raise RuntimeError(msg)
     # FIXME: can we reliably decode as UTF-8?
     # scrapy list does `print(list)`
     tmp = out.decode('utf-8').splitlines()
@@ -153,10 +151,8 @@ def get_spider_list(project, runner=None, pythonpath=None, version=''):
 def _to_native_str(text, encoding='utf-8', errors='strict'):
     if isinstance(text, str):
         return text
-    if not isinstance(text, (bytes, six.text_type)):
+    if not isinstance(text, (bytes, str)):
         raise TypeError('_to_native_str must receive a bytes, str or unicode '
                         'object, got %s' % type(text).__name__)
-    if six.PY2:
-        return text.encode(encoding, errors)
-    else:
-        return text.decode(encoding, errors)
+
+    return text.decode(encoding, errors)

--- a/scrapyd/website.py
+++ b/scrapyd/website.py
@@ -1,8 +1,8 @@
 import socket
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 
 from scrapy.utils.misc import load_object
-from six.moves.urllib.parse import urlparse
 from twisted.application.service import IServiceCollection
 from twisted.web import resource, static
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         'twisted>=17.9',
         'scrapy>=2.0.0',
         'setuptools',
-        'six',
         'w3lib',
         'zope.interface',
     ],


### PR DESCRIPTION
We don't need the bindings since we support python 3.6+.

@jpmckinney also: Can i open another PR to [drop support of python 3.6](https://endoflife.date/python) aswell?