### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         'Environment :: No Input/Output (Daemon)',
         'Topic :: Internet :: WWW/HTTP',
     ],
-    python_requires='>=3.7',
     entry_points={
         'console_scripts': [
             'scrapyd = scrapyd.scripts.scrapyd_run:main'

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -56,6 +55,7 @@ setup(
         'Environment :: No Input/Output (Daemon)',
         'Topic :: Internet :: WWW/HTTP',
     ],
+    python_requires='>=3.7',
     entry_points={
         'console_scripts': [
             'scrapyd = scrapyd.scripts.scrapyd_run:main'


### PR DESCRIPTION
@jpmckinney I had added 3.11 support by accident, let me know if you want to add support for this version aswell so i raise other PR too :)