### PR TITLE
Update minimum python version in docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,7 +12,7 @@ Requirements
 Scrapyd depends on the following libraries, but the installation process
 takes care of installing the missing ones:
 
-* Python 3.6 or above
+* Python 3.7 or above
 * Scrapy 2.0 or above
 * Twisted 17.9 or above
 


### PR DESCRIPTION
Some leftover from:
- https://github.com/scrapy/scrapyd/pull/459

CI is failing but is not because of my change.