### PR TITLE
proxy prefix for Scrapyd (web interface) templates added

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -197,7 +197,7 @@ A class that stores finished jobs. There are 2 implementations provided:
 * ``scrapyd.jobstorage.MemoryJobStorage`` (default) jobs are stored in memory and lost when the daemon is restarted
 * ``scrapyd.jobstorage.SqliteJobStorage`` jobs are persisted in a Sqlite database in ``dbs_dir``
 
-If another backend is needed, one can implement its own class by implementing the IJobStorage 
+If another backend is needed, one can implement its own class by implementing the IJobStorage
 interface.
 
 .. _eggstorage:
@@ -211,6 +211,14 @@ The default value is ``scrapyd.eggstorage.FilesystemEggStorage``.
 This implementation stores eggs in the directory specified by the :ref:`eggs_dir` setting.
 
 You can implement your own egg storage: for example, to store eggs remotely.
+
+prefix_header
+----------
+
+.. versionadded:: 1.4.2
+
+Behind a reverse proxy set a custom header (see proxy settings) to pass the application specific base-path to scrapyd used in monitor templates.
+Default to ``x-forwarded-prefix``
 
 node_name
 ---------

--- a/scrapyd/default_scrapyd.conf
+++ b/scrapyd/default_scrapyd.conf
@@ -20,6 +20,7 @@ launcher    = scrapyd.launcher.Launcher
 spiderqueue = scrapyd.spiderqueue.SqliteSpiderQueue
 webroot     = scrapyd.website.Root
 eggstorage  = scrapyd.eggstorage.FilesystemEggStorage
+prefix_header = x-forwarded-prefix
 
 [services]
 schedule.json     = scrapyd.webservice.Schedule


### PR DESCRIPTION
To use Scrapyd behind a reverse proxy the base-path can passed via proxy header, provided in the config file. 
In the website templates the proxy_prefix is added to provided internal links (jobs, logs, cancel).

closes #480 