### PR TITLE
Add configuration via env vars

### DIFF
--- a/scrapyd/app.py
+++ b/scrapyd/app.py
@@ -18,7 +18,11 @@ from scrapyd.scheduler import SpiderScheduler
 
 def create_wrapped_resource(webcls, config, app):
     username = config.get('username', '')
+    if os.environ.get("SCRAPYD_USERNAME"):
+        username = os.environ["SCRAPYD_USERNAME"]
     password = config.get('password', '')
+    if os.environ.get("SCRAPYD_PASSWORD"):
+        password = os.environ["SCRAPYD_PASSWORD"]
     if ':' in username:
         sys.exit("The `username` option contains illegal character ':', "
                  "check and update the configuration file of Scrapyd")


### PR DESCRIPTION
Allows to override `scrapyd.conf` config values `http_port`, `bind_address`, `username`, `password` via env vars `SCRAPYD_HTTP_PORT`, `SCRAPYD_BIND_ADDRESS`, `SCRAPYD_USERNAME`, `SCRAPYD_PASSWORD`.