### PR TITLE
ci: remove obsolete cache-dependency-path option

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,6 @@ jobs:
         with:
           python-version: 3.9
           cache: pip
-          cache-dependency-path: setup.py
       - run: pip install --upgrade pre-commit
       - run: pre-commit run --all-files
       - run: pip install --upgrade check-manifest setuptools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: setup.py
       - run: pip install -e .[test]
       # Python 3.12 deprecates pkg_resources (also used by py-html-checker).
       # https://github.com/pytest-dev/pytest-twisted/issues/183


### PR DESCRIPTION
Hi, this is my first PR to the project. Please feel free to close the PR, if the change is unwanted.

This PR removes the obsolete "cache-dependency-path" option. There is no `setup.py` in the repository, so this option has no effect.