### PR TITLE
add `requires-python` setting to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.5.0"
 authors = [{name = "Scrapy developers", email = "info@scrapy.org"}]
 description = "A service for running Scrapy spiders, with an HTTP API"
 readme = "README.rst"
+requires-python = ">=3.9"
 license = {text = "BSD"}
 urls = {Homepage = "https://github.com/scrapy/scrapyd"}
 classifiers = [
@@ -60,7 +61,6 @@ zip-safe = false  # The scrapyd.__main__ module requires the txapp.py file to be
 
 [tool.ruff]
 line-length = 119
-target-version = "py38"
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
Hi @jpmckinney,

I would like to propose add `requires-python` setting to your `pyproject.toml`. `scrapy` itself already does this:
https://github.com/scrapy/scrapy/blob/c03fb2abb8c354c56c4e8363fc602d49f956c280/pyproject.toml#L51

If you add this setting, `ruff` will also respect that setting, which makes the `target-version` redundant.

Let me know what you think.

Refs:
- https://packaging.python.org/en/latest/specifications/pyproject-toml/#requires-python
- https://docs.astral.sh/ruff/settings/#target-version