### PR TITLE
minor, documentation: add a bit more clarity to the status.json response

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -137,6 +137,8 @@ Parameters
   ``project``
     the project name
 
+This will report back the job's status (as ``currstate`` key), which should be one of ``'pending'``, ``'running'`` or ``'finished'``. 
+
 Example:
 
 .. code-block:: shell-session


### PR DESCRIPTION
list all the possible currstate values in a response to the status.json request